### PR TITLE
FEAT : 워크스페이스 유저 초대 요청 컨트롤 하자

### DIFF
--- a/src/main/java/com/sellertool/server/domain/invite_member/controller/InviteMemberApiV1.java
+++ b/src/main/java/com/sellertool/server/domain/invite_member/controller/InviteMemberApiV1.java
@@ -38,6 +38,17 @@ public class InviteMemberApiV1 {
     }
 
     @RequiredLogin
+    @GetMapping("/requested")
+    public ResponseEntity<?> searchByRequested() {
+        Message message = new Message();
+
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+        message.setData(inviteMemberBusinessService.searchM2OJByRequested());
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @RequiredLogin
     @PostMapping("/one")
     public ResponseEntity<?> createOne(@RequestBody InviteMemberDto inviteMemberDto) {
         Message message = new Message();
@@ -68,6 +79,44 @@ public class InviteMemberApiV1 {
         }
 
         inviteMemberBusinessService.deleteByWorkspaceIdAndInviteMemberId(workspaceId, inviteMemberId);
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @RequiredLogin
+    @PostMapping("/{inviteMemberId}/action-accept")
+    public ResponseEntity<?> actionAccept(@PathVariable(value = "inviteMemberId") Object inviteMemberIdObj) {
+        Message message = new Message();
+        UUID inviteMemberId = null;
+
+        try {
+            inviteMemberId = UUID.fromString(inviteMemberIdObj.toString());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new NotMatchedFormatException("형식이 올바르지 않습니다.");
+        }
+
+        inviteMemberBusinessService.acceptMemberInWorkspace(inviteMemberId);
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @RequiredLogin
+    @PostMapping("/{inviteMemberId}/action-reject")
+    public ResponseEntity<?> actionReject(@PathVariable(value = "inviteMemberId") Object inviteMemberIdObj) {
+        Message message = new Message();
+        UUID inviteMemberId = null;
+
+        try {
+            inviteMemberId = UUID.fromString(inviteMemberIdObj.toString());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new NotMatchedFormatException("형식이 올바르지 않습니다.");
+        }
+
+        inviteMemberBusinessService.rejectMemberInWorkspace(inviteMemberId);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 

--- a/src/main/java/com/sellertool/server/domain/invite_member/repository/InviteMemberRepositoryCustom.java
+++ b/src/main/java/com/sellertool/server/domain/invite_member/repository/InviteMemberRepositoryCustom.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 @Repository
 public interface InviteMemberRepositoryCustom {
     List<InviteMemberM2OJProj> qSelectM2OJByWorkspaceId(UUID workspaceId);
+    List<InviteMemberM2OJProj> qSelectM2OJByUserId(UUID userId);
+    List<InviteMemberM2OJProj> qSelectM2OJById(UUID inviteMemberId);
 }

--- a/src/main/java/com/sellertool/server/domain/invite_member/repository/InviteMemberRepositoryImpl.java
+++ b/src/main/java/com/sellertool/server/domain/invite_member/repository/InviteMemberRepositoryImpl.java
@@ -42,4 +42,44 @@ public class InviteMemberRepositoryImpl implements InviteMemberRepositoryCustom 
         QueryResults<InviteMemberM2OJProj> results = customQuery.fetchResults();
         return results.getResults();
     }
+
+    @Override
+    public List<InviteMemberM2OJProj> qSelectM2OJByUserId(UUID userId) {
+        JPQLQuery customQuery = query.from(qInviteMemberEntity)
+                .select(
+                        Projections.fields(
+                                InviteMemberM2OJProj.class,
+                                qInviteMemberEntity.as("inviteMemberEntity"),
+                                qUserEntity.as("userEntity"),
+                                qWorkspaceEntity.as("workspaceEntity")
+                        )
+                )
+                .join(qUserEntity).on(qUserEntity.id.eq(qInviteMemberEntity.userId))
+                .join(qWorkspaceEntity).on(qWorkspaceEntity.id.eq(qInviteMemberEntity.workspaceId))
+                .where(qInviteMemberEntity.userId.eq(userId))
+                ;
+
+        QueryResults<InviteMemberM2OJProj> results = customQuery.fetchResults();
+        return results.getResults();
+    }
+
+    @Override
+    public List<InviteMemberM2OJProj> qSelectM2OJById(UUID inviteMemberId) {
+        JPQLQuery customQuery = query.from(qInviteMemberEntity)
+                .select(
+                        Projections.fields(
+                                InviteMemberM2OJProj.class,
+                                qInviteMemberEntity.as("inviteMemberEntity"),
+                                qUserEntity.as("userEntity"),
+                                qWorkspaceEntity.as("workspaceEntity")
+                        )
+                )
+                .join(qUserEntity).on(qUserEntity.id.eq(qInviteMemberEntity.userId))
+                .join(qWorkspaceEntity).on(qWorkspaceEntity.id.eq(qInviteMemberEntity.workspaceId))
+                .where(qInviteMemberEntity.id.eq(inviteMemberId))
+                ;
+
+        QueryResults<InviteMemberM2OJProj> results = customQuery.fetchResults();
+        return results.getResults();
+    }
 }

--- a/src/main/java/com/sellertool/server/domain/invite_member/service/InviteMemberService.java
+++ b/src/main/java/com/sellertool/server/domain/invite_member/service/InviteMemberService.java
@@ -29,7 +29,20 @@ public class InviteMemberService {
         return proj;
     }
 
+    public List<InviteMemberM2OJProj> qSelectM2OJByUserId(UUID userId){
+        List<InviteMemberM2OJProj> proj = inviteMemberRepository.qSelectM2OJByUserId(userId);
+        return proj;
+    }
+
     public void deleteByWorkspaceIdAndInviteMemberId(UUID workspaceId, UUID inviteMemberId) {
         inviteMemberRepository.deleteByWorkspaceIdAndInviteMemberId(workspaceId, inviteMemberId);
+    }
+
+    public InviteMemberM2OJProj qSelectM2OJById(UUID inviteMemberId) {
+        return inviteMemberRepository.qSelectM2OJById(inviteMemberId).stream().findFirst().orElse(null);
+    }
+
+    public void deleteByEntity(InviteMemberEntity inviteMemberEntity) {
+        inviteMemberRepository.delete(inviteMemberEntity);
     }
 }

--- a/src/main/java/com/sellertool/server/domain/workspace/service/WorkspaceBusinessService.java
+++ b/src/main/java/com/sellertool/server/domain/workspace/service/WorkspaceBusinessService.java
@@ -100,7 +100,7 @@ public class WorkspaceBusinessService {
                 .id(WORKSPACE_MEMBER_ID)
                 .workspaceId(WORKSPACE_ID)
                 .userId(USER_ID)
-                .grade(WorkspaceMemberStaticVariable.GRADE_MASTER)
+                .grade(WorkspaceMemberStaticVariable.GRADE_HOST)
                 .createdAt(DateTimeUtils.getCurrentDateTime())
                 .readPermissionYn(WorkspaceMemberStaticVariable.READ_PERMISSION_Y)
                 .writePermissionYn(WorkspaceMemberStaticVariable.WRITE_PERMISSION_Y)

--- a/src/main/java/com/sellertool/server/domain/workspace_member/utils/WorkspaceMemberStaticVariable.java
+++ b/src/main/java/com/sellertool/server/domain/workspace_member/utils/WorkspaceMemberStaticVariable.java
@@ -13,5 +13,6 @@ public interface WorkspaceMemberStaticVariable {
     public final String DELETE_PERMISSION_Y = "y";
     public final String DELETE_PERMISSION_N = "n";
 
-    public final String GRADE_MASTER = "마스터";
+    public final String GRADE_HOST = "HOST";
+    public final String GRADE_MEMBER = "MEMBER";
 }


### PR DESCRIPTION
InviteMemberRepositoryCustom => qSelectM2OJByUserId : 유저 아이디를 이용해서 M2OJ 가져오기 만듬
InviteMemberRepositoryCustom => qSelectM2OJById : inviteMemberId 를 이용해서 M2OJ 가져오기 만듬
InviteMemberBusinessService => searchM2OJByRequested : 유저별 현재 대기중인 초대 요청 리스트 가져옴
InviteMemberBusinessService => acceptMemberInWorkspace : 현재 대기중인 초대 요청에서 요청을 수락하는 로직 만듬
InviteMemberBusinessService => rejectMemberInWorkspace : 현재 대기중인 초대 요청에서 요청을 거절하는 로직 만듬